### PR TITLE
prevent scrolling to first focus

### DIFF
--- a/library/src/main/java/at/allaboutapps/web/webview/A3WebView.java
+++ b/library/src/main/java/at/allaboutapps/web/webview/A3WebView.java
@@ -97,6 +97,7 @@ public class A3WebView extends FrameLayout {
 
     webSettings.setBuiltInZoomControls(false);
     webSettings.setSupportZoom(false);
+    webSettings.setNeedInitialFocus(false);     // prevent scrolling to first focus by not focusing
     webSettings.setDisplayZoomControls(false);
 
     mWebView.setWebViewClient(new WebViewClient(settings));


### PR DESCRIPTION
prevent scrolling to first focus by disabling initial focus in websettings